### PR TITLE
Allow routine names to be nullable, per grammar…

### DIFF
--- a/lib/fez/Routine.py
+++ b/lib/fez/Routine.py
@@ -92,6 +92,8 @@ FLAGS = {
     "UseMarkFilteringSet": 0x10
 }
 
+ROUTINE_ID = 0
+
 import fontFeatures
 from . import FEZVerb
 
@@ -126,14 +128,20 @@ class Routine(FEZVerb):
 
     def action(self, args):
         (routinename, statements, flags_languages) = args
-        routinename = self.parser.expand_statements(routinename)
+        routinename = self.parser.expand_statements(routinename, cannot_fail=False)
         flags_languages = self.parser.expand_statements(flags_languages)
 
         flags, languages = flags_languages
         statements = self.parser.expand_statements(statements)
 
-        if routinename is not None:
+        if len(routinename) > 0:
             routinename = routinename[0].value
+        elif routinename is not None:
+            global ROUTINE_ID
+            routinename = "FEZUnnamedRoutine{}".format(ROUTINE_ID)
+            ROUTINE_ID += 1
+        else:
+            raise ValueError
 
         if flags is None: flags = []
 

--- a/lib/fez/__init__.py
+++ b/lib/fez/__init__.py
@@ -420,7 +420,7 @@ class FezParser:
         ret = [x for x in collapse(results) if x and not isinstance(x, str)]
         return ret
 
-    def expand_statements(self, statements):
+    def expand_statements(self, statements, cannot_fail=True):
         rv = []
         # Gross
         if isinstance(statements, tuple):
@@ -433,7 +433,7 @@ class FezParser:
                 returned = callback()
                 if returned:
                     rv.extend(returned)
-                else:
+                elif cannot_fail:
                     warnings.warn("Bad callback in verb %s" % verb)
             else:
                 rv.extend(args)


### PR DESCRIPTION
master raises error on FEZ code documented to work

This assigns names like `FEZUnnamedRoutine1` in the FEA code.

```fea
Feature liga {
    Routine {
        Substitute period period period -> ellipsis;
        Substitute period period -> nldr;
    } <<latn/ENG>>;
    Routine bb {
        Substitute period period period -> ellipsis;
        Substitute period period -> nldr;
    } <<latn/TRK>>;
    Routine {
        Substitute period period period -> ellipsis;
        Substitute period period -> nldr;
    } <<latn/SPA>>;
};
```

becomes…

```fea
lookup FEZUnnamedRoutine0 {
    lookupflag 0;
    ;
    sub period period period by ellipsis;
    sub period period by nldr;
} FEZUnnamedRoutine0;

lookup bb {
    lookupflag 0;
    ;
    sub period period period by ellipsis;
    sub period period by nldr;
} bb;

lookup FEZUnnamedRoutine1 {
    lookupflag 0;
    ;
    sub period period period by ellipsis;
    sub period period by nldr;
} FEZUnnamedRoutine1;

feature liga {
    script latn;
    language ENG;
            lookup FEZUnnamedRoutine0;

} liga;

feature liga {
    script latn;
    language TRK;
            lookup bb;

} liga;

feature liga {
    script latn;
    language SPA;
            lookup FEZUnnamedRoutine1;

} liga;
```